### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The [GTFS-to-geojson](https://github.com/blinktaginc/gtfs-to-geojson) app create
 Install `node-gtfs` directly from [npm](https://npmjs.org):
 
     npm install gtfs -g
+    
+Note: Do __not__ install mongoose. If you do choose to install it, install it as a peerDependency.
 
 ## Command-line example
 


### PR DESCRIPTION
We'll end up with multiple mongoose instances if we do.
When we require mongoose and connect, it does not have any of the gtfs models and thus none of the queries will work.